### PR TITLE
Update FloatingActionButtonViewRenderer.cs

### DIFF
--- a/xamarin.forms/FabSampleForms/Droid/FloatingActionButtonViewRenderer.cs
+++ b/xamarin.forms/FabSampleForms/Droid/FloatingActionButtonViewRenderer.cs
@@ -122,7 +122,7 @@ namespace FabSampleForms.Droid
 			{
 				try
 				{
-					var drawableNameWithoutExtension = Path.GetFileNameWithoutExtension(imageName);
+					var drawableNameWithoutExtension = Path.GetFileNameWithoutExtension(imageName).ToLower();
 					var resources = context.Resources;
 					var imageResourceName = resources.GetIdentifier(drawableNameWithoutExtension, "drawable", context.PackageName);
 					fab.SetImageBitmap(Android.Graphics.BitmapFactory.DecodeResource(context.Resources, imageResourceName));


### PR DESCRIPTION
Although Xamarin allows uppercase drawable names, Android does not. That means, that I can name my icon `AddIcon.png` but the Xamarin compiler will render it to `addicon.png` in Android. That's why it makes sense to lower the `drawableNameWithoutExtension` variable to avoid errors here. Otherwise a user might add an uppercase drawable to its project that works everywhere but here.
